### PR TITLE
Reconcile new and old model estimation scripts

### DIFF
--- a/package/pickoffgame/R/apply_runner_outcome.R
+++ b/package/pickoffgame/R/apply_runner_outcome.R
@@ -33,7 +33,7 @@ apply_runner_outcome <- function(pre_state_reduced, runner_outcome) {
         runner_outcome == "S-" ~ "000"
       ),
       outs = outs + (runner_outcome %in% c("P+", "S-")),
-      post_state_reduced = ifelse(outs == 3, "0", construct_state(bases, outs, balls, strikes))
+      post_state_reduced = ifelse(outs == 3, "0", construct_state(first, bases, outs, balls, strikes))
     ) |>
     dplyr::pull(post_state_reduced)
 }

--- a/package/pickoffgame/R/construct_state.R
+++ b/package/pickoffgame/R/construct_state.R
@@ -3,6 +3,7 @@
 #' Combines base occupancy, outs, balls, strikes, and optionally disengagements 
 #' into a unified string identifier for state-transition modeling.
 #'
+#' @param first Binary 0/1 indicating whether this is the first play of the current event.
 #' @param bases Character string representing base occupancy (e.g., "100" for a runner on first base).
 #' @param outs Integer or character count of outs (0, 1, or 2).
 #' @param balls Integer or character count of balls (0 to 3).
@@ -15,7 +16,7 @@
 #'
 #' @importFrom glue glue
 #' @export
-construct_state <- function(bases, outs, balls, strikes, disengagements = NULL) {
+construct_state <- function(first, bases, outs, balls, strikes, disengagements = NULL) {
 
   if (!is.null(disengagements)) {
     disengagement_string <- paste0("_", disengagements)
@@ -23,7 +24,7 @@ construct_state <- function(bases, outs, balls, strikes, disengagements = NULL) 
     disengagement_string <- ""
   }
 
-  state <- glue::glue("{bases}_{outs}_{balls}{strikes}{disengagement_string}")
+  state <- glue::glue("{first}_{bases}_{outs}_{balls}{strikes}{disengagement_string}")
 
   return(state)
 }

--- a/package/pickoffgame/R/deconstruct_state.R
+++ b/package/pickoffgame/R/deconstruct_state.R
@@ -18,13 +18,15 @@
 #' @importFrom tibble tibble
 #' @export
 deconstruct_state <- function(state) {
-  bases <- substring(state, 1, 3)
-  outs <- as.integer(substring(state, 5, 5))
-  balls <- as.integer(substring(state, 7, 7))
-  strikes <- as.integer(substring(state, 8, 8))
-  disengagements <- as.integer(substring(state, 10, 10))
+  first <- substring(state, 1, 1)
+  bases <- substring(state, 3, 5)
+  outs <- as.integer(substring(state, 7, 7))
+  balls <- as.integer(substring(state, 9, 9))
+  strikes <- as.integer(substring(state, 10, 10))
+  disengagements <- as.integer(substring(state, 12, 12))
   return(
     tibble::tibble(
+      first = first,
       bases = bases,
       outs = outs,
       balls = balls,

--- a/package/pickoffgame/R/update_state.R
+++ b/package/pickoffgame/R/update_state.R
@@ -20,6 +20,7 @@
 #' @importFrom dplyr mutate coalesce
 #' @export
 update_state <- function(state,
+                         new_first = NA,
                          new_bases = NA,
                          new_outs = NA,
                          new_balls = NA,
@@ -28,13 +29,14 @@ update_state <- function(state,
   new_state <- state |>
     deconstruct_state() |>
     dplyr::mutate(
+      first = dplyr::coalesce(new_first, first),
       bases = dplyr::coalesce(new_bases, bases),
       outs = dplyr::coalesce(new_outs, outs),
       balls = dplyr::coalesce(new_balls, balls),
       strikes = dplyr::coalesce(new_strikes, strikes),
       disengagements = dplyr::coalesce(new_disengagements, disengagements)
     ) |>
-    with(construct_state(bases, outs, balls, strikes, disengagements))
+    with(construct_state(first, bases, outs, balls, strikes, disengagements))
 
   return(new_state)
 }

--- a/package/pickoffgame/R/update_state.R
+++ b/package/pickoffgame/R/update_state.R
@@ -26,6 +26,7 @@ update_state <- function(state,
                          new_balls = NA,
                          new_strikes = NA,
                          new_disengagements = NA) {
+
   new_state <- state |>
     deconstruct_state() |>
     dplyr::mutate(
@@ -34,9 +35,14 @@ update_state <- function(state,
       outs = dplyr::coalesce(new_outs, outs),
       balls = dplyr::coalesce(new_balls, balls),
       strikes = dplyr::coalesce(new_strikes, strikes),
-      disengagements = dplyr::coalesce(new_disengagements, disengagements)
+      disengagements = dplyr::coalesce(new_disengagements, disengagements),
+      state = ifelse(
+        test = nchar(state) == 1,
+        yes = state,    # don't update the state if it is a terminal end-of-inning state
+        no = construct_state(first, bases, outs, balls, strikes, disengagements)
+      )
     ) |>
-    with(construct_state(first, bases, outs, balls, strikes, disengagements))
+    dplyr::pull(state)
 
   return(new_state)
 }

--- a/package/pickoffgame/R/wrangle_data.R
+++ b/package/pickoffgame/R/wrangle_data.R
@@ -67,12 +67,16 @@ wrangle_data <- function(play,
         TRUE ~ batter_description
       ),
       is_po_attempt = type == "pickoff",
-      is_po_success = dplyr::coalesce(is_pickoff, FALSE),
+      # There are a couple of rare plays in which a pickoff is labelled as successful but there are
+      # no outs on the play. We choose to define this as an unsuccessful pickoff attempt.
+      is_po_success = dplyr::coalesce(is_pickoff, FALSE) & (post_outs - pre_outs) > 0,
       is_sb_attempt = !is_po_attempt & (is_stolen_base | is_caught_stealing),
       is_sb_success = is_sb_attempt & is_stolen_base,
       is_1b_only = !is.na(pre_runner_1b_id) & is.na(pre_runner_2b_id) & is.na(pre_runner_3b_id),
+      is_full_count_two_outs = (pre_balls == 3) & (pre_strikes == 2) & (pre_outs == 2),
       runner_outcome = dplyr::case_when(
-        !is_1b_only ~ "N",   # runner outcome only refers to 1B occupied with 2B & 3B empty
+        # we consider only runner outcome with 1B occupied 2B & 3B empty, not full count two outs
+        !is_1b_only | is_full_count_two_outs ~ "N",
         is_po_attempt & is_po_success ~ "P+",
         is_po_attempt & !is_po_success ~ "P-",
         is_sb_attempt & is_sb_success ~ "S+",
@@ -110,7 +114,10 @@ wrangle_data <- function(play,
     # after runner movement, and post-disengagements is not zero at the end of a plate appearance.
     dplyr::group_by(game_id, event_index) |>
     dplyr::mutate(
+      is_first_play_of_event = 1:dplyr::n() == 1,
       is_last_play_of_event = 1:dplyr::n() == dplyr::n(),
+      pre_first = as.integer(is_first_play_of_event),
+      post_first = as.integer(is_last_play_of_event),
       # Within each event, group plays into stints between runner movement
       disengagement_stint = ((!is_last_play_of_event) & (pre_bases != post_bases)) |>
         dplyr::lag(1) |>
@@ -135,15 +142,21 @@ wrangle_data <- function(play,
       # Reset count at the end of a plate appearance
       post_balls = ifelse(is_last_play_of_event, 0, post_balls),
       post_strikes = ifelse(is_last_play_of_event, 0, post_strikes),
-      pre_state = construct_state(pre_bases, pre_outs, pre_balls, pre_strikes, pre_disengagements),
-      pre_state_reduced = substring(pre_state, 1, 8),
+      pre_state = construct_state(pre_first, pre_bases, pre_outs, pre_balls, pre_strikes, pre_disengagements),
+      pre_state_reduced = construct_state(pre_first, pre_bases, pre_outs, pre_balls, pre_strikes),
       post_state = ifelse(
         test = post_outs == 3,
         yes = as.character(runs_on_play),
-        no = construct_state(post_bases, post_outs, post_balls, post_strikes, post_disengagements)
+        no = construct_state(post_first, post_bases, post_outs, post_balls, post_strikes, post_disengagements)
       ),
-      post_state_reduced = substring(post_state, 1, 8),
-    )
+      post_state_reduced = ifelse(
+        test = post_outs == 3,
+        yes = as.character(runs_on_play),
+        no = construct_state(post_first, post_bases, post_outs, post_balls, post_strikes)
+      )
+    ) |>
+    # We exclude step-offs, intentional balls, automatic balls/strikes
+    dplyr::filter(type %in% c("pickoff", "pitch"))
 
   return(game_state)
 }

--- a/scripts/estimate_models_new.R
+++ b/scripts/estimate_models_new.R
@@ -1,16 +1,17 @@
 
+# TODO: Handle full-count strike-em-out throw-em-out (currently debit for strikeout is assigned to steal decision)
+
 fit_glmer_models <- FALSE
 value_iteration_threshold <- 1e-4   # well-accepted default
 
-# READ DATA ----
+# WRANGLE DATA ----
+logger::log_info("Wrangling data")    # 1 minute
 
 data_2022 <- pickoffgame::read_data(2022)
 data_2023 <- pickoffgame::read_data(2023)
 
 event_map <- data.table::fread("input/data/batter_event.csv")
 pitch_map <- data.table::fread("input/data/batter_pitch.csv")
-
-# WRANGLE DATA ----
 
 game_state_2023 <- pickoffgame::wrangle_data(
   play = data_2023$play,
@@ -36,18 +37,13 @@ game_state_2022 <- pickoffgame::wrangle_data(
 
 game_state <- dplyr::bind_rows(game_state_2022, game_state_2023)
 
-
-# FIT RUNNER OUTCOME MODELS ----
-
 data_glmer <- game_state |>
   dplyr::group_by(pre_runner_1b_id) |>
   dplyr::filter(
     # For modeling purposes, we consider only plays in which only first base is occupied
-    !is.na(pre_runner_1b_id),
-    is.na(pre_runner_2b_id),
-    is.na(pre_runner_3b_id),
+    is_1b_only,
     # Exclude full count with two outs because runners because these are not really steal attempts
-    pre_balls < 3 | pre_strikes < 2 | pre_outs < 2,
+    !is_full_count_two_outs,
     # We include only runners who attempted at least three stolen bases in our sample
     sum(is_sb_attempt) >= 3,
     # The runner taking the lead from first base should match the runner on first base
@@ -66,23 +62,29 @@ data_glmer <- game_state |>
     year = as.factor(year),
   )
 
-if (fit_glmer_models) {
 
-  fit_po_attempt <- lme4::glmer(    # 2 minutes
+# FIT RUNNER OUTCOME MODELS ----
+if (fit_glmer_models) {
+  logger::log_info("Fitting runner outcome models")   # 10 minutes
+
+  logger::log_info("  Estimating GLMM for PO attempt probability")    # 2 minutes
+  fit_po_attempt <- lme4::glmer(
     formula = is_po_attempt ~ year + pre_outs + pre_balls + pre_strikes + pre_disengagements +
       lead_distance_centered + (1 | pitcher_id),
     data = data_glmer,
     family = binomial()
   )
   
-  fit_po_success <- lme4::glmer(    # 2 seconds
+  logger::log_info("  Estimating GLMM for PO success probability")    # 0 minutes
+  fit_po_success <- lme4::glmer(
     formula = is_po_success ~ lead_distance_centered + (1 | pitcher_id),
     data = data_glmer |>
       dplyr::filter(is_po_attempt),
     family = binomial()
   )
   
-  fit_sb_attempt <- lme4::glmer(    # 11 minutes
+  logger::log_info("  Estimating GLMM for SB attempt probability")    # 7 minutes
+  fit_sb_attempt <- lme4::glmer(
     is_sb_attempt ~ pre_outs + pre_balls + pre_strikes + pre_disengagements +
       sprint_speed_centered + (1 | runner_id) + (1 | pitcher_id) + arm_strength_centered + (1 | catcher_id),
     data = data_glmer |>
@@ -90,23 +92,37 @@ if (fit_glmer_models) {
     family = binomial()
   )
   
-  fit_sb_success <- lme4::glmer(    # 30 seconds
+  logger::log_info("  Estimating GLMM for SB success probability")    # 1 minute
+  fit_sb_success <- lme4::glmer(
     is_stolen_base ~ year + lead_distance_centered +
       sprint_speed_centered + (1 | runner_id) + (1 | pitcher_id) + arm_strength_centered + (1 | catcher_id),
     data = data_glmer |>
       dplyr::filter(is_sb_attempt),
     family = binomial
   )
+
+  saveRDS(fit_po_success, "output/models/fit_po_success.rds")
+  saveRDS(fit_po_attempt, "output/models/fit_po_attempt.rds")
+  saveRDS(fit_sb_success, "output/models/fit_sb_success.rds")
+  saveRDS(fit_sb_attempt, "output/models/fit_sb_attempt.rds")
+
+} else {
+
+  fit_po_success <- readRDS("output/models/fit_po_success.rds")
+  fit_po_attempt <- readRDS("output/models/fit_po_attempt.rds")
+  fit_sb_success <- readRDS("output/models/fit_sb_success.rds")
+  fit_sb_attempt <- readRDS("output/models/fit_sb_attempt.rds")
 }
 
 
-# COMPUTE CONDITIONAL STATE TRANSITION PROBABILITIES ----
+# COMPUTE STATE TRANSITION PROBABILITIES ----
+logger::log_info("Computing state transition probabilities")    # 0 minutes
 
 # Compute empirical transition probabilities between reduced states
 # TODO: Fix the problem of a 0-0 triple with runner on second looking just like a stolen base.
 #       To do this, we'd need to include a new batter indicator in the state space.
-transition_conditional_observed <- game_state_2023 |> # TODO: include 2022?
-  dplyr::filter(type %in% c("pickoff", "pitch")) |>   # don't count stepoffs as transitions
+transition_conditional_observed <- game_state_2023 |> # TODO: decide whether to include
+  dplyr::filter(type %in% c("pickoff", "pitch")) |>   # TODO: decide whether to keep this
   dplyr::group_by(pre_state_reduced, runner_outcome, post_state_reduced) |>
   dplyr::summarize(n = dplyr::n(), reward = mean(runs_on_play), .groups = "drop") |>
   dplyr::group_by(pre_state_reduced, runner_outcome) |>
@@ -119,7 +135,9 @@ transition_conditional_unobserved <- tidyr::expand_grid(
   pre_state_reduced = unique(transition_conditional_observed$pre_state_reduced),
   runner_outcome = unique(transition_conditional_observed$runner_outcome)
 ) |>
-  dplyr::filter(pickoffgame::deconstruct_state(pre_state_reduced)$bases == "100") |>
+  dplyr::mutate(pre = pickoffgame::deconstruct_state(pre_state_reduced)) |>
+  # When the action space is null, we don't need to fill in conditional transitions
+  dplyr::filter(pre$bases == "100", !(pre$outs == 2 & pre$balls == 3 & pre$strikes == 2)) |>
   dplyr::anti_join(
     y = transition_conditional_observed,
     by = c("pre_state_reduced", "runner_outcome")
@@ -130,22 +148,34 @@ transition_conditional_unobserved <- tidyr::expand_grid(
     reward = 0
   )
 
+# This is where we append disengagements back onto the state. The logic is tricky and might be
+# worth revisiting. For example, we do not correctly handle the (rare) case where bases, count and
+# outs stay the same (and it's not a new batter). In this case, we should increment disengagements.
 transition_conditional <- transition_conditional_observed |>
   dplyr::bind_rows(transition_conditional_unobserved) |>
   # Expand reduced state to full state by tacking on disengagements
   tidyr::expand_grid(pre_disengagements = 0:2) |>
   dplyr::mutate(
+    pre = pickoffgame::deconstruct_state(pre_state_reduced),
+    post = pickoffgame::deconstruct_state(post_state_reduced),
     pre_state = pickoffgame::update_state(
       state = pre_state_reduced,
       new_disengagements = pre_disengagements
     ),
     post_disengagements = pre_disengagements + ifelse(runner_outcome %in% c("P+", "P-"), 1, 0),
+    is_end_of_pa = post$first == 1,
+    is_runner_movement = pre$bases != post$bases,
     post_state = dplyr::case_when(
       # If the reduced post-state is a terminal end-of-inning state, do not append disengagements
       nchar(post_state_reduced) == 1 ~ post_state_reduced,
+      # If the transition is end of plate appearance or runner movement, reset disengagements
+      is_end_of_pa | is_runner_movement ~ pickoffgame::update_state(
+        state = post_state_reduced,
+        new_disengagements = 0
+      ),
       # If the pre-state is not 1B occupied, 2B & 3B empty, then post-disengagements must be zero
       # because we only count disengagements with 1B occupied, 2B & 3B empty
-      pickoffgame::deconstruct_state(pre_state)$bases != "100" ~ pickoffgame::update_state(
+      pre$bases != "100" ~ pickoffgame::update_state(
         state = post_state_reduced,
         new_disengagements = 0
       ),
@@ -160,9 +190,6 @@ transition_conditional <- transition_conditional_observed |>
   ) |>
   dplyr::select(pre_state, runner_outcome, post_state, prob, reward)
 
-
-# COMPUTE STATE TRANSITION PROBABILITIES ----
-
 runner_outcome_grid <- transition_conditional |>
   dplyr::distinct(pre_state) |>
   tidyr::expand_grid(
@@ -171,30 +198,34 @@ runner_outcome_grid <- transition_conditional |>
   ) |>
   dplyr::mutate(
     year = factor(2023, levels = c(2022, 2023)),
-    pre_bases = pickoffgame::deconstruct_state(pre_state)$bases,
-    pre_outs = pickoffgame::deconstruct_state(pre_state)$outs,
-    pre_balls = pickoffgame::deconstruct_state(pre_state)$balls,
-    pre_strikes = pickoffgame::deconstruct_state(pre_state)$strikes,
-    pre_disengagements = factor(
-      x = pickoffgame::deconstruct_state(pre_state)$disengagements,
-      levels = 0:2
-    ),
+    pre = pickoffgame::deconstruct_state(pre_state),
+    pre_bases = pre$bases,
+    pre_outs = pre$outs,
+    pre_balls = pre$balls,
+    pre_strikes = pre$strikes,
+    pre_disengagements = factor(pre$disengagements, levels = 0:2),
     lead_distance_centered = lead_distance - 10,
     sprint_speed_centered = 0,
     arm_strength_centered = 0,
-    pitcher_id = "0"
-  )
+    pitcher_id = "0",
+    is_1b_only = pre$bases == "100",
+    is_full_count_two_outs = (pre$balls == 3) & (pre$strikes == 2) & (pre$outs == 2)
+  ) |>
+  # Action space is null unless only 1B is occupied without full count and two strikes
+  dplyr::filter(lead_distance == 0 | (is_1b_only & !is_full_count_two_outs))
 
 runner_outcome_prob <- runner_outcome_grid |>
   dplyr::mutate(
     prob_po_attempt = ifelse(
-      test = pre_bases == "100",  # we only consider runner outcomes for 1B occupied, 2B & 3B empty
+      # our model only allows pickoffs and steals with only 1B occupied, not full count two outs
+      test = is_1b_only & !is_full_count_two_outs,
       yes = predict(fit_po_attempt, newdata = runner_outcome_grid, type = "response", re.form = NA),
       no = 0
     ),
     prob_po_success = predict(fit_po_success, newdata = runner_outcome_grid, type = "response", re.form = NA),
     prob_sb_attempt = ifelse(
-      test = pre_bases == "100",  # we only consider runner outcomes for 1B occupied, 2B & 3B empty
+      # our model only allows pickoffs and steals with only 1B occupied, not full count two outs
+      test = is_1b_only & !is_full_count_two_outs,
       yes = predict(fit_sb_attempt, newdata = runner_outcome_grid, type = "response", re.form = NA),
       no = 0
     ),
@@ -220,12 +251,13 @@ transition <- runner_outcome_prob |>
   dplyr::group_by(pre_state, lead_distance, post_state) |>
   dplyr::summarize(
     prob = sum(prob_runner_outcome * prob_conditional),
-    reward = sum(prob_runner_outcome * reward),   # reward should not depend on runner outcome
+    # reward should not depend on runner outcome
+    reward = weighted.mean(reward, w = prob_runner_outcome * prob_conditional),
     .groups = "drop"
   )
 
-
-# VALUE ITERATION ----
+# PERFORM VALUE ITERATION ----
+logger::log_info("Performing value iteration")    # 0 minutes
 
 state <- transition |>
   dplyr::distinct(state = pre_state) |>
@@ -238,7 +270,7 @@ while (max_value_change > value_iteration_threshold) {
   state_update <- state |>
     dplyr::left_join(transition, by = c("state" = "pre_state")) |>
     dplyr::left_join(state, by = c("post_state" = "state"), suffix = c("_before", "_after")) |>
-    # The value of terminal end-of-inning states is defintionally zero
+    # The value of terminal end-of-inning states is definitionally zero
     dplyr::mutate(value_after = ifelse(nchar(post_state) == 1, 0, value_after)) |>
     dplyr::group_by(state, value_before, lead_distance) |>
     dplyr::summarize(value = sum(prob * (reward + value_after)), .groups = "drop") |>
@@ -252,7 +284,6 @@ while (max_value_change > value_iteration_threshold) {
 
   state <- state_update |>
     dplyr::select(state, action = lead_distance, value)
-  
-  print(max_value_change)
 }
 
+logger::log_info("Done")


### PR DESCRIPTION
I tediously compared the discrepancies between `scripts/estimate_models_old.R` and `scripts/estimate_models_new.R`. Through this process, I identified a few bugs in both scripts (detailed below). After resolving all of these bugs, now the results are very similar to each other. They're not identical because there are still nuanced differences between the scripts, but they're close enough that I'm happy.

I fixed the bugs in the new script, but I did not fix the bugs in the old script because that was out of scope for this PR. From here, I plan to move forward with the new script for further enhancements.

Old:
- We had this nefarious little bug [here](https://github.com/jfhahn2/pickoff-game-theory/blob/855b39c561770b62f932cc33e025ed6c5750a3dc/scripts/estimate_models_old.R#L150) because of how we pooled across different numbers of disengagements to estimate conditional transition probabilities. We assumed for non-pickoff attempts, non-stolen base attempts, that if the post-count was 0-0, then the post-disengagements would be zero. This logic, however, does not allow for step-offs without pickoff attempts, which we included in the training data for empirical transition probabilities. Based on this logic, the state transition for a step-off in an 0-0 count looks just like a run scoring (the batter gets a hit and all runners replace each other). This resulted in over-estimating run expectation because every 0-0 step-off resulted in a run.
- We classified "runner going" on a walk as a successful steal [here](https://github.com/jfhahn2/pickoff-game-theory/blob/855b39c561770b62f932cc33e025ed6c5750a3dc/scripts/estimate_models_old.R#L204). This meant that the reward for attempting a steal in a 3-ball count as very high. If you were safe, then you got an additional baserunner on first base. Our logic assumes the base-out transition depends on the runner outcome, but in this case it's the other way around.
- We (appropriately) [excluded](https://github.com/jfhahn2/pickoff-game-theory/blob/855b39c561770b62f932cc33e025ed6c5750a3dc/scripts/estimate_models_old.R#L84-L93) full-count, two-out pitches when estimating pickoff and stolen base attempt probabilities, but [not](https://github.com/jfhahn2/pickoff-game-theory/blob/855b39c561770b62f932cc33e025ed6c5750a3dc/scripts/estimate_models_old.R#L563-L567) when predicting them.
- We were not consistent with how we defined runner outcomes for (1) estimating runner outcome probabilities and (2) estimating state transition probabilities conditional on runner outcomes.

New:
- As in the old script, I forgot to disallow pickoff and stolen base attempts for full-count, two-out pitches when predicting runner outcome probabilities.
- There was a significant bug [here](https://github.com/jfhahn2/pickoff-game-theory/blob/855b39c561770b62f932cc33e025ed6c5750a3dc/scripts/estimate_models_new.R#L223) in calculating rewards for state transitions because `prob_runner_outcome` does not sum to one within `post_state`.
- When re-appending disengagement counts to reduced states, I forgot to reset disengagements on runner movement or end of plate appearance.